### PR TITLE
fix: ensure PaperTrail whodunnit tracking for both web and API routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,13 @@ class ApplicationController < ActionController::Base
   # end
 
   def find_current_auditor
-    current_user if current_user&.superadmin?
+    # For API routes, track the service making the change
+    if respond_to?(:current_service) && current_service
+      "Service: #{current_service.name}"
+    else
+      # For web routes, track all authenticated users
+      current_user
+    end
   end
 
   def not_found


### PR DESCRIPTION
Fixes ##97

Updated the `find_current_auditor` method in ApplicationController to properly track changes made through both web interface and API endpoints.

**Changes:**
- Track all authenticated users for web routes (not just superadmins)
- Track service names for API routes to identify which service made changes
- Ensures PaperTrail audit logs have proper whodunnit attribution

🤖 Generated with [Claude Code](https://claude.ai/code)